### PR TITLE
Removes the BIC-element from FinInstnId if a BIC is not supplied

### DIFF
--- a/SepaWriter.Test/Utils/XmlUtilsTest.cs
+++ b/SepaWriter.Test/Utils/XmlUtilsTest.cs
@@ -27,7 +27,7 @@ namespace SpainHoliday.SepaWriter.Test.Utils
             var el = (XmlElement)xml.AppendChild(xml.CreateElement("Document"));
 
             XmlUtils.CreateBic(el, new SepaIbanData { UnknownBic = true});
-            Assert.AreEqual("<FinInstnId><BIC><Othr><Id>NOTPROVIDED</Id></Othr></BIC></FinInstnId>", el.InnerXml);
+            Assert.AreEqual("<FinInstnId><Othr><Id>NOTPROVIDED</Id></Othr></FinInstnId>", el.InnerXml);
         }
     }
 }

--- a/SepaWriter/Utils/XmlUtils.cs
+++ b/SepaWriter/Utils/XmlUtils.cs
@@ -27,7 +27,7 @@ namespace SpainHoliday.SepaWriter.Utils
         {
             if (iban.UnknownBic)
             {
-                element.NewElement("FinInstnId").NewElement("BIC").NewElement("Othr").NewElement("Id", "NOTPROVIDED");
+                element.NewElement("FinInstnId").NewElement("Othr").NewElement("Id", "NOTPROVIDED");
             }
             else
             {


### PR DESCRIPTION
The Othr element is placed directly under FinInstnId instead as expected
according to the standard.

See the xsd (https://github.com/SpainHoliday/sepawriter/blob/master/SepaWriter/Xsd/pain.008.001.02.xsd) on line 373:

<xs:complexType name="FinancialInstitutionIdentification7">
        <xs:sequence>
            <xs:element maxOccurs="1" minOccurs="0" name="BIC" type="BICIdentifier"/>
            <xs:element maxOccurs="1" minOccurs="0" name="ClrSysMmbId" type="ClearingSystemMemberIdentification2"/>
            <xs:element maxOccurs="1" minOccurs="0" name="Nm" type="Max140Text"/>
            <xs:element maxOccurs="1" minOccurs="0" name="PstlAdr" type="PostalAddress6"/>
            <xs:element maxOccurs="1" minOccurs="0" name="Othr" type="GenericFinancialIdentification1"/>
        </xs:sequence>
    </xs:complexType>